### PR TITLE
Add TODO item

### DIFF
--- a/src/CropNerGUI.py
+++ b/src/CropNerGUI.py
@@ -15,9 +15,12 @@ import tkinter as tk
 from tkinter import filedialog as fd
 from tkinter.scrolledtext import ScrolledText
 
-# TODO: Even though users can add their own named entities, the tools does not recognize these user
-# defined named entities once they've quit the application. Make customized additions to the GUI
-# persistent across sessions.
+# TODO: Even though users can add their own named entities, the tool does not recognize these user
+# defined named entities once they've quit the application. Basically, when a user customizes the GUI
+# the changes do not persist across sessions. Make customized additions to the GUI persistent across sessions.
+# One approach to implementing this would be to add a starting prompt that asks a user if they want to
+# 1) Annotate crop data 2) Annotate user data or 3) Review annotations. If they choose 2 or 3, build the GUI by
+# first scanning their annotations to determine what Named Entity tags (e.g., ALAS) to include in the GUI
 
 # 1) WE NEED TO RESOLVE STANDARDIZING THINGS SUCH AS
 # ROUGH AWNS OR AWNS ARE ROUGH. NOTE: Maybe compound traits


### PR DESCRIPTION
Even though users can add their own named entities, the tool does not recognize these user
defined named entities once they've quit the application. Basically, when a user customizes the GUI
the changes do not persist across sessions. Make customized additions to the GUI persistent across sessions.
One approach to implementing this would be to add a starting prompt that asks a user if they want to
1) Annotate crop data 2) Annotate user data or 3) Review annotations. If they choose 2 or 3, build the GUI by
first scanning their annotations to determine what Named Entity tags (e.g., ALAS) to include in the GUI